### PR TITLE
Qt5-compliant implementation of is_gui_app()

### DIFF
--- a/src/irisnet/noncore/processquit.cpp
+++ b/src/irisnet/noncore/processquit.cpp
@@ -92,7 +92,7 @@ static ProcessQuit *g_pq = 0;
 inline bool is_gui_app()
 {
 #ifdef QT_GUI_LIB
-	return (QApplication::type() != QApplication::Tty);
+	return dynamic_cast<QGuiApplication*>(qApp);
 #else
 	return false;
 #endif


### PR DESCRIPTION
Avoid using of obsolete (since Qt5) members of QApplication used to check if we are GUI application. Use dynamic_cast to QGuiApplication instead, which could be a little slower, but seems to be the recommended way.

Turned out to be important for KF5-porting of Kopete, which uses internal copy of libiris.
